### PR TITLE
GO111MODULE needs to be on to go get micro

### DIFF
--- a/network.md
+++ b/network.md
@@ -40,7 +40,7 @@ Below is a quick guide to getting started.
 From source
 
 ```
-go get github.com/micro/micro
+GO111MODULE=on go get github.com/micro/micro
 ```
 
 Docker image


### PR DESCRIPTION
Because micro defines specific versions in go.mod, you need to be running with modules enabled to go get. Otherwise, odd build failures occur under various dependencies that may have drifted.