### PR TITLE
Added missing import in example `time`

### DIFF
--- a/docs/pages/tutorials/getting-started.markdown
+++ b/docs/pages/tutorials/getting-started.markdown
@@ -143,6 +143,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/micro/go-micro/v2"
 	proto "github.com/micro/examples/helloworld/proto"


### PR DESCRIPTION
The `time` package was missing from the example in the getting started guide.